### PR TITLE
Make sinatra_for_dummies example listen on all interfaces

### DIFF
--- a/ruby/sinatra_for_dummies/extreme_startup.rb
+++ b/ruby/sinatra_for_dummies/extreme_startup.rb
@@ -18,6 +18,7 @@ end
 server = ExtremeStartup.new
 
 configure do
+  set :bind, '0.0.0.0'
   set :port, 1337
 end
 


### PR DESCRIPTION
We had this issue in the last session I ran where participants who chose this example had to add a specific config to make Sinatra listen on all interfaces.